### PR TITLE
fix: correct WSL socket file name

### DIFF
--- a/app/wsl.go
+++ b/app/wsl.go
@@ -23,7 +23,7 @@ func listenUnixSock(filename string) (string, net.Listener, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	path := filepath.Join(home, CYGWIN_SOCK)
+	path := filepath.Join(home, WSL_SOCK)
 	os.Remove(path)
 	l, err := net.Listen("unix", path)
 	return path, l, err


### PR DESCRIPTION
In 73810bdd sockets were moved to %USERPROFILE% and somehow WSL socket is created in cygwin socket now. Cygwin app is executing ater and then overwrites WSL socket rendering WSL integration broken.