### PR TITLE
Fix issue after wsl shut down

### DIFF
--- a/app/vsock.go
+++ b/app/vsock.go
@@ -186,10 +186,11 @@ func (s *VSock) onClick() {
 	}
 
 	// socat 1.7.4 support vsock,
-	// `SOCKET-CONNECT` can replaced with `VSOCK-CONNECT:2:0x22223333`
+	// `SOCKET-CONNECT` can be replaced with `VSOCK-CONNECT:2:0x22223333`
 	help := `export SSH_AUTH_SOCK=/tmp/wincrypt-hv.sock
 ss -lnx | grep -q $SSH_AUTH_SOCK
 if [ $? -ne 0 ]; then
+	rm -f $SSH_AUTH_SOCK
   (setsid nohup socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork SOCKET-CONNECT:40:0:x0000x33332222x02000000x00000000 >/dev/null 2>&1)
 fi`
 	if utils.MessageBox(s.AppId().FullName()+" (OK to copy):", help, utils.MB_OKCANCEL) == utils.IDOK {


### PR DESCRIPTION
The socket file will not be removed if wsl directly shutdown, so remove it if exists.