### PR TITLE
Update wsl_tutorial.md

### DIFF
--- a/doc/wsl_tutorial.md
+++ b/doc/wsl_tutorial.md
@@ -44,7 +44,8 @@ Execute following commands, provide new PIN and PUK when prompted:
  1. Plug your YubiKey back.
  1. Run Certificate Manager Tool (`certmgr.msc`) and in *Certificates - Current User \ Personal \ Certificates* your certificate named **SSH key** should be visible.
 
-***NOTE:*** If the certificate is not visible, make sure [Allow ECC certificates to be used for logon and authentication](https://docs.microsoft.com/en-us/windows/security/identity-protection/smart-cards/smart-card-group-policy-and-registry-settings#allow-ecc-certificates-to-be-used-for-logon-and-authentication) in *Group Policy Editor (gpedit.msc) > Computer Configuration > Administrative Templates > Windows Components > Smart Card* is enabled.
+***NOTE:*** Please make sure [Allow ECC certificates to be used for logon and authentication](https://docs.microsoft.com/en-us/windows/security/identity-protection/smart-cards/smart-card-group-policy-and-registry-settings#allow-ecc-certificates-to-be-used-for-logon-and-authentication) in *Group Policy Editor (gpedit.msc) > Computer Configuration > Administrative Templates > Windows Components > Smart Card* is enabled.
+
 ***NOTE#2:*** You should also install the [YubiKey Smart Card Minidriver](https://www.yubico.com/support/download/smart-card-drivers-tools/) if you want to work with ECC algorithm certificates.
 
 ### Confiure YubiKey for SSH in WLS and target machine


### PR DESCRIPTION
#56 
In some cases, even if the Group Policy has not been modified, the certificates can also appear in the Personal Certificate Storage. But when you log in to SSH, an error occurs.