### PR TITLE
Add ability to remove PIN cache

### DIFF
--- a/capi/wincapi.go
+++ b/capi/wincapi.go
@@ -122,6 +122,7 @@ func certGetCertificateContextProperty(context *syscall.CertContext, dwPropId ui
 	return int(r0)
 }
 
+// nCryptSetPropertyString sets a string value for a named property for a CNG key storage object.
 func nCryptSetPropertyString(hObject uintptr, pszProperty string, pbInput string, dwFlags uint32) (err error) {
 
 	pszPropertyPtr, _ := syscall.UTF16PtrFromString(pszProperty)
@@ -154,6 +155,8 @@ func nCryptSetPropertyString(hObject uintptr, pszProperty string, pbInput string
 	return nil
 }
 
+// cryptAcquireCertificatePrivateKey obtains the private key for a certificateContext, returning a CNG NCRYPT_KEY_HANDLE
+// or a HCRYPTPROV depending on the flags given.
 func cryptAcquireCertificatePrivateKey(certContext uintptr, flags uint32) (provContext uintptr, err error) {
 	pvParameters := uint32(0)
 	phCryptProvOrNCryptKey := uintptr(0)

--- a/capi/wincapi.go
+++ b/capi/wincapi.go
@@ -299,7 +299,6 @@ func Sign(alg string, cert *Certificate, data []byte) (*pkcs7.PKCS7, error) {
 	return pkcs7.Parse(sign)
 }
 
-func SetPINCache(b bool) {
-	fmt.Printf("Setting PIN Cache to %v\n", b)
+func SetDisablePINCache(b bool) {
 	disablePINCache = b
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/buptczq/WinCryptSSHAgent/capi"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -36,6 +37,7 @@ var applications = []app.Application{
 
 var installHVService = flag.Bool("i", false, "Install Hyper-V Guest Communication Services")
 var disableCapi = flag.Bool("disable-capi", false, "Disable Windows Crypto API")
+var disablePINCache = flag.Bool("disable-pin-cache", false, "Clear the Smart Card PIN Cache after each operation")
 
 func installService() {
 	if !utils.IsAdmin() {
@@ -121,6 +123,8 @@ func main() {
 
 	// context
 	ctx, cancel := context.WithCancel(context.Background())
+
+	capi.SetPINCache(*disablePINCache)
 
 	// agent
 	var ag agent.Agent

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func main() {
 	// context
 	ctx, cancel := context.WithCancel(context.Background())
 
-	capi.SetPINCache(*disablePINCache)
+	capi.SetDisablePINCache(*disablePINCache)
 
 	// agent
 	var ag agent.Agent


### PR DESCRIPTION
This pull adds a new argument `--disable-pin-cache`

If enabled, it will clear the PIN cache after every Sign operation so users are prompted to enter the PIN every time when using Smart Cards.

I have only tested with Smart Cards, so needs testing to make sure setting `NCRYPT_PIN_PROPERTY` on non-smart-card certs is a noop.

Fixes #58 

Further work on holding onto the private key context until a timeout is reached is required for #49 


