### PR TITLE
Add --smart-card-logon-only option

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var applications = []app.Application{
 
 var installHVService = flag.Bool("i", false, "Install Hyper-V Guest Communication Services")
 var disableCapi = flag.Bool("disable-capi", false, "Disable Windows Crypto API")
+var smartCardLogonOnly = flag.Bool("smart-card-logon-only", false, "Advertise Smart Card Logon keys only")
 
 func installService() {
 	if !utils.IsAdmin() {
@@ -129,7 +130,7 @@ func main() {
 	} else if *disableCapi {
 		ag = sshagent.NewKeyRingAgent()
 	} else {
-		cag := new(sshagent.CAPIAgent)
+		cag := &sshagent.CAPIAgent{SmartCardLogonOnly: *smartCardLogonOnly}
 		defer cag.Close()
 		defaultAgent := sshagent.NewKeyRingAgent()
 		ag = sshagent.NewWrappedAgent(defaultAgent, []agent.Agent{agent.Agent(cag)})

--- a/sshagent/eku.go
+++ b/sshagent/eku.go
@@ -43,3 +43,19 @@ func FilterCertificateEKU(cert *capi.Certificate) bool {
 	}
 	return true
 }
+
+func FilterCertificateSmartCardLogon(cert *capi.Certificate) bool {
+	flagClientAuth := false
+	flagSmartCardLogon := false
+	for i := range cert.ExtKeyUsage {
+		if cert.ExtKeyUsage[i] == x509.ExtKeyUsageClientAuth {
+			flagClientAuth = true
+		}
+	}
+	for i := range cert.UnknownExtKeyUsage {
+		if cert.UnknownExtKeyUsage[i].Equal(oidExtKeyUsageSmartCardLogon) {
+			flagSmartCardLogon = true
+		}
+	}
+	return flagClientAuth && flagSmartCardLogon
+}


### PR DESCRIPTION
This option filters all but keys for smart card logon.

This addresses the problem where too many SSH keys are advertised causing the SSH server to disconnect on too many auth attempts.

Both of the following OIDs must be present for a certificate to be treated as a smart card logon certificate:

* Client Authentication (1.3.6.1.5.5.7.3.2)
* Smart Card Logon (1.3.6.1.4.1.311.20.2.2)

See https://learn.microsoft.com/en-us/troubleshoot/windows-server/certificates-and-public-key-infrastructure-pki/enabling-smart-card-logon-third-party-certification-authorities

Fixes rfdonnelly/WinCryptSSHAgent#2